### PR TITLE
Fix TxPool.PackTxsWithBytes to use encoded transaction size instead of unsafe.Sizeof

### DIFF
--- a/core/txpool.go
+++ b/core/txpool.go
@@ -6,7 +6,6 @@ import (
 	"blockEmulator/utils"
 	"sync"
 	"time"
-	"unsafe"
 )
 
 type TxPool struct {
@@ -73,7 +72,7 @@ func (txpool *TxPool) PackTxsWithBytes(max_bytes int) []*Transaction {
 	txNum := len(txpool.TxQueue)
 	currentSize := 0
 	for tx_idx, tx := range txpool.TxQueue {
-		currentSize += int(unsafe.Sizeof(*tx))
+		currentSize += len(tx.Encode())
 		if currentSize > max_bytes {
 			txNum = tx_idx
 			break


### PR DESCRIPTION
## Note
I noticed this might be a potential issue — please let me know if my understanding is off.

## Summary

This PR fixes `TxPool.PackTxsWithBytes` so that it uses the **encoded transaction size**
instead of `unsafe.Sizeof(*tx)` when deciding how many transactions to pack.

Using `unsafe.Sizeof` only accounts for the in-memory struct header size and ignores
the actual payload stored behind slices, strings, etc. This can lead to significant
underestimation of the real block/tx batch size.


## Changes
```go
// Pack transaction for a proposal (use 'BlocksizeInBytes' to control)
func (txpool *TxPool) PackTxsWithBytes(max_bytes int) []*Transaction {
	txpool.lock.Lock()
	defer txpool.lock.Unlock()

	txNum := len(txpool.TxQueue)
	currentSize := 0
	for tx_idx, tx := range txpool.TxQueue {
        //currentSize += int(unsafe.Sizeof(*tx)) 
		currentSize += len(tx.Encode())
		if currentSize > max_bytes {
			txNum = tx_idx
			break
		}
	}

	txs_Packed := txpool.TxQueue[:txNum]
	txpool.TxQueue = txpool.TxQueue[txNum:]
	return txs_Packed
}
```